### PR TITLE
Arxivng 1073 1074 Delete File and Delete All Files requests

### DIFF
--- a/filemanager/controllers/upload.py
+++ b/filemanager/controllers/upload.py
@@ -5,7 +5,8 @@ from datetime import datetime
 import json
 import logging
 
-from werkzeug.exceptions import NotFound, BadRequest, InternalServerError, NotImplemented, SecurityError
+from werkzeug.exceptions import NotFound, BadRequest, InternalServerError, \
+    NotImplemented, SecurityError
 
 from werkzeug.datastructures import FileStorage
 from flask.json import jsonify
@@ -328,7 +329,8 @@ def upload(upload_id: int, file: FileStorage, archive: str) -> Response:
         # Most submissions can get by with default size limitations so we'll add a warning
         # message for the upload (this will appear on upload page and get logged). This
         # warning will get generated in process/upload.py and not here.
-        logger.error(f"Upload 'archive' not specified. Oversize calculation will use default values.")
+        logger.error("Upload 'archive' not specified. Oversize calculation "
+                     + "will use default values.")
 
     # If this is a new upload then we need to create a workspace and add to database.
     if upload_id is None:
@@ -376,7 +378,8 @@ def upload(upload_id: int, file: FileStorage, archive: str) -> Response:
             # NOTE: This will need to be migrated to task.py using Celery at
             #       some point in future. Depends in time it takes to process
             #       uploads.retrieve
-            logger.info(f"{upload_obj.upload_id}: Upload files to existing workspace: file='{file.filename}'")
+            logger.info(f"{upload_obj.upload_id}: Upload files to existing "
+                        + f"workspace: file='{file.filename}'")
 
             # Keep track of how long processing upload_obj takes
             start_datetime = datetime.now()
@@ -427,7 +430,8 @@ def upload(upload_id: int, file: FileStorage, archive: str) -> Response:
             # Store in DB
             uploads.update(upload_obj)
 
-            logger.info(f"{upload_obj.upload_id}: Processed upload. Saved to DB. Preparing upload summary.")
+            logger.info(f"{upload_obj.upload_id}: Processed upload. "
+                        + "Saved to DB. Preparing upload summary.")
 
             # Do we want affirmative log messages after processing each request
             # or maybe just report errors like:

--- a/filemanager/domain.py
+++ b/filemanager/domain.py
@@ -116,5 +116,3 @@ class Upload(Data):
 
     lock = Property('lock', str)
     """Lock state of upload workspace. 'LOCKED', 'UNLOCKED'"""
-
-

--- a/filemanager/process/upload.py
+++ b/filemanager/process/upload.py
@@ -287,7 +287,7 @@ submitter."""
                 check_path = os.path.join(src_directory, public_file_path)
                 if os.path.exists(check_path):
                     self.log(f"Path appears to be valid and contain "
-                             + "subdirectory: '{public_file_path}' <=> '{filename}'")
+                             + f"subdirectory: '{public_file_path}' <=> '{filename}'")
                     # TODO: Can someone hurt us here? Is it now safe to use original
                     # TODO: path or should I edit 'secure' path. I believe what I'm doing is ok.
                     file_path = check_path
@@ -336,20 +336,19 @@ submitter."""
         #
         # For now we will remove file by moving it to 'removed' directory
         src_directory = self.get_source_directory()
-        self.log(f"Removing all files under directory '{src_directory}'")
+        self.log(f"Delete all files under directory '{src_directory}'")
 
         for dir_entry in os.listdir(src_directory):
             file_path = os.path.join(src_directory, dir_entry)
             try:
                 if os.path.isfile(file_path):
-                    #os.unlink(file_path)
-                    self.log(f"Removing file:'{dir_entry}'")
-                # elif os.path.isdir(file_path): shutil.rmtree(file_path)
+                    self.log(f"Delete file:'{dir_entry}'")
+                    os.unlink(file_path)
                 elif os.path.isdir(file_path):
-                    self.log(f"Removing directory:'{dir_entry}'")
+                    self.log(f"Delete directory:'{dir_entry}'")
+                    shutil.rmtree(file_path)
             except Exception as rme:
                 self.log(f"Error while removing all files: '{rme}'")
-                print(rme)
                 raise
 
 

--- a/filemanager/process/upload.py
+++ b/filemanager/process/upload.py
@@ -7,7 +7,7 @@ import shutil
 import tarfile
 import logging
 
-from werkzeug.exceptions import BadRequest, NotFound
+from werkzeug.exceptions import BadRequest, NotFound, SecurityError
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
 
@@ -244,28 +244,54 @@ submitter."""
 
         """
 
-        self.log('********** Delete File ************')
+        self.log('********** Delete File ************\n')
 
         # Check whether client is trying to damage system with invalid path
 
         # Sanitize file name
         filename = secure_filename(public_file_path)
 
+        # Our UI will never attempt to delete a file path containing components that attempt
+        # to escape out of workspace and this would be removed by secure_filename().
+        # This error must be propagated to wider notification level beyond source log.
+        if re.search(r'^/|^\.\./|\.\./', public_file_path):
+            # should never start with '/' or '../' or contain '..' anywhere in path.
+            message = f"SECURITY WARNING: file to delete contains illegal constructs: '{public_file_path}'"
+            self.log(message)
+            raise SecurityError(message)
+
+        # Secure filename should not change length of valid file path (but it will
+        # mess with directory slashes '/')
         # TODO: Come up with better file path checker. We allow subdirectories
         # TODO: and secure_filename strips them (/ => _)
-        if 0 and public_file_path != filename:
-            self.log("Possible Security Violation: Sanitized file path "
-                     + f"'{filename}' is different from '{public_file_path}'")
-            # TODO: I'm not sure how well secure_filename maps to attempted security
-            # TODO: violation. Need to check whether it does other mutations.
+        # The length of file path should not change (need to check secure_filename)
+        # so if length changes generate warning.
+        if len(public_file_path) != len(filename):
+            message = f"SECURITY WARNING: sanitized file is different length: '{filename}' <=> '{public_file_path}'"
+            self.log(message)
+            raise SecurityError(message)
 
-            # Rasie an exception without giving the client indication of a
-            # potential security violation.
-            raise BadRequest(UPLOAD_DELETE_FILE_FAILED)
-
-        # Resolve path of file
+        # Resolve reletive path of file to filesystem
         src_directory = self.get_source_directory()
         file_path = os.path.join(src_directory, filename)
+
+        # secure_filename will eliminate '/' making paths to subdirectories
+        # impossible to resolve. Make assumption we caught bad actors with checks above.
+
+        # Check if original path might be subdirectory.
+        # We've made it past serious threat checks above.
+        if not os.path.exists(file_path) and re.search(r'_', filename) and re.search(r'/', public_file_path):
+            if len(filename) == len(public_file_path):
+                # May be issue of directory delimiter converted to '_'
+                # Check if raw path exists
+                check_path = os.path.join(src_directory, public_file_path)
+                if os.path.exists(check_path):
+                    self.log(f"Path appears to be valid and contain "
+                             + "subdirectory: '{public_file_path}' <=> '{filename}'")
+                    # TODO: Can someone hurt us here? Is it now safe to use original
+                    # TODO: path or should I edit 'secure' path. I believe what I'm doing is ok.
+                    file_path = check_path
+                    filename = public_file_path
 
         # Need to determine whether file exists
         if os.path.exists(file_path):
@@ -274,11 +300,9 @@ submitter."""
             # Flatten public path to eliminate directory structure
             clean_public_path = re.sub('/', '_', public_file_path)
 
-
-
             # Generate path in removed directory
             removed_path = os.path.join(self.get_removed_directory(), clean_public_path)
-            self.log(f"Deleted file: '{clean_public_path}'")
+            self.log(f"Delete file: '{filename}'")
 
 
             if shutil.move(file_path, removed_path):
@@ -288,10 +312,10 @@ submitter."""
                 self.log(f"Moved file from {file_path} to {removed_path}")
                 return True
             else:
-                self.log(f"*** FAILED to remove file '{file_path}' ***")
+                self.log(f"*** FAILED to remove file '{file_path}'/{clean_public_path} ***")
                 return False
         else:
-            self.log(f"File to delete not found: '{public_file_path}'")
+            self.log(f"File to delete not found: '{public_file_path}' '{filename}'")
             raise NotFound(UPLOAD_FILE_NOT_FOUND)
 
 
@@ -306,7 +330,7 @@ submitter."""
 
         """
 
-        self.log('********** Delete ALL Files ************')
+        self.log('********** Delete ALL Files ************\n')
 
         # Cycle through list of files under src directory and remove them.
         #
@@ -314,6 +338,19 @@ submitter."""
         src_directory = self.get_source_directory()
         self.log(f"Removing all files under directory '{src_directory}'")
 
+        for dir_entry in os.listdir(src_directory):
+            file_path = os.path.join(src_directory, dir_entry)
+            try:
+                if os.path.isfile(file_path):
+                    #os.unlink(file_path)
+                    self.log(f"Removing file:'{dir_entry}'")
+                # elif os.path.isdir(file_path): shutil.rmtree(file_path)
+                elif os.path.isdir(file_path):
+                    self.log(f"Removing directory:'{dir_entry}'")
+            except Exception as rme:
+                self.log(f"Error while removing all files: '{rme}'")
+                print(rme)
+                raise
 
 
     def get_upload_directory(self) -> str:
@@ -457,7 +494,7 @@ submitter."""
         None
         """
 
-        self.log('******** Check Files *****')
+        self.log('\n******** Check Files *****\n\n')
 
         source_directory = self.get_source_directory()
 
@@ -961,12 +998,12 @@ submitter."""
         #      + " FilenameBase: " + os.path.basename(file.filename)
         #      + " Mime: " + file.mimetype + '\n')
 
-        self.log('********** File Upload ************')
+        self.log('\n********** File Upload ************\n\n')
 
         # Move uploaded archive/file to source directory
         self.deposit_upload(file)
 
-        self.log('******** File Upload Processing *****')
+        self.log('\n******** File Upload Processing *****\n\n')
 
         from filemanager.utilities.unpack import unpack_archive
         # Unpack upload archive (if necessary). Completes minor cleanup.

--- a/filemanager/routes/upload_api.py
+++ b/filemanager/routes/upload_api.py
@@ -69,6 +69,27 @@ def upload_files(upload_id: int) -> tuple:
 
     return jsonify(data), status_code, headers
 
+@blueprint.route('<int:upload_id>/<path:public_file_path>', methods=['DELETE'])
+@authorization.scoped('write:upload')
+def delete_file(upload_id: int, public_file_path: str) -> tuple:
+    """Delete individual file."""
+
+    data, status_code, headers = upload.client_delete_file(upload_id, public_file_path)
+
+    return jsonify(data), status_code, headers
+
+
+@blueprint.route('<int:upload_id>/delete_all', methods=['POST'])
+@authorization.scoped('write:upload')
+def delete_all_files(upload_id: int) -> tuple:
+    """Delete all files in specified workspace."""
+
+    data, status_code, headers = upload.client_delete_all_files(upload_id)
+
+    return jsonify(data), status_code, headers
+
+
+
 @blueprint.route('<int:upload_id>', methods=['DELETE'])
 @authorization.scoped('admin:upload')
 def workspace_delete(upload_id: int) -> tuple:

--- a/tests/test_routes_upload_api.py
+++ b/tests/test_routes_upload_api.py
@@ -323,6 +323,27 @@ class TestUploadAPIRoutes(TestCase):
         except jsonschema.exceptions.SchemaError as e:
             self.fail(e)
 
+        # Delete a file (normal call)
+        #public_file_path = "../../subdir/this_file"
+        #public_file_path = "this_file"
+        public_file_path = "lipics-logo-bw.pdf"
+        from requests.utils import quote
+        encoded_file_path = quote(public_file_path, safe='')
+        #encoded_file_path = public_file_path
+        print(f"ENCODED:{encoded_file_path}\n")
+        #response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{encoded_file_path}",
+        response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
+                                   headers={'Authorization': token})
+        print("Delete File Response:\n" + str(response.data) + '\n')
+        self.assertEqual(response.status_code, 200, "Delete an individual file.")
+
+        # Delete all files in my workspace (normal)
+        response = self.client.post(f"/filemanager/api/{upload_data['upload_id']}/delete_all",
+                                   headers={'Authorization': token},
+                                   content_type='multipart/form-data')
+        print("Delete All Files Response:\n" + str(response.data) + '\n')
+        self.assertEqual(response.status_code, 200, "Delete all user-uploaded files.")
+
         # Delete the workspace
 
         # Create admin token for deleting upload workspace

--- a/tests/test_routes_upload_api.py
+++ b/tests/test_routes_upload_api.py
@@ -246,6 +246,241 @@ class TestUploadAPIRoutes(TestCase):
 
         # TODO: Add size checks (when implemented)
 
+
+    def test_delete_file(self) -> None:
+        """
+        Test delete file operation.
+
+        These tests will focus on triggering delete failures.
+
+        """
+        # Create a token for writing to upload workspace
+        token = generate_token(self.app,
+                               {'scope': ['read:upload', 'write:upload']})
+
+
+        # Upload a gzipped tar archive package containing files to delete.
+        cwd = os.getcwd()
+        testfiles_dir = os.path.join(cwd, 'tests/test_files_upload')
+        filepath = os.path.join(testfiles_dir, 'UploadWithANCDirectory.tar.gz')
+        # Prepare gzipped tar submission for upload
+        filename = os.path.basename(filepath)
+
+        # Upload files to delete
+        # TODO: Make my life easier by holding upload_id steady
+        # response = self.client.post('/filemanager/api/',
+        response = self.client.post('/filemanager/api/15',
+                                    data={
+                                        # 'file': (io.BytesIO(b"abcdef"), 'test.jpg'),
+                                        #      'file': (open(filepath, 'rb'), 'test.tar.gz'),
+                                        'file': (open(filepath, 'rb'), filename),
+                                    },
+                                    headers={'Authorization': token},
+                                    #        content_type='application/gzip')
+                                    content_type='multipart/form-data')
+
+        self.assertEqual(response.status_code, 201, "Accepted and processed uploaded Submission Contents")
+
+        # This upload should work but we'll check the response anyway
+        with open('schema/resources/uploadResult.json') as f:
+            schema = json.load(f)
+
+        try:
+            jsonschema.validate(json.loads(response.data), schema)
+        except jsonschema.exceptions.SchemaError as e:
+            self.fail(e)
+
+        upload_data: Dict[str, Any] = json.loads(response.data)
+
+        # Try a few valid deletions
+
+        # Delete a file (normal call)
+        # public_file_path = "../../subdir/this_file"
+        # public_file_path = "this_file"
+        #public_file_path = "lipics-logo-bw.pdf"
+        public_file_path = "accessibilityMeta.sty"
+        from requests.utils import quote
+        encoded_file_path = quote(public_file_path, safe='')
+        public_file_path = encoded_file_path
+        print(f"ENCODED:{public_file_path}\n")
+
+        response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
+                                      headers={'Authorization': token})
+        print(f"Delete File Response:'{public_file_path}'\n" + str(response.data) + '\n')
+        self.assertEqual(response.status_code, 200,
+                         "Delete an individual file: '{public_file_path}'.")
+
+        # Now try to break delete
+
+        # This file path is a potential security threat. Attempt to detect such deviant
+        # file deletions without alerting the client.
+        public_file_path = "../../subdir/this_file"
+        public_file_path = quote(public_file_path, safe='')
+        response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
+                                      headers={'Authorization': token})
+        print(f"Delete hacker file path Response:'{public_file_path}'\n" + str(response.data) + '\n')
+        self.assertEqual(response.status_code, 404,
+                         f"Delete a file outside of workspace: '{public_file_path}'.")
+
+        # Another file path is a potential security threat. Attempt to detect such deviant
+        # file deletions without alerting the client.
+        public_file_path = "anc/../../etc/passwd"
+        public_file_path = quote(public_file_path, safe='')
+        response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
+                                      headers={'Authorization': token})
+        print(f"Delete hacker file path Response:'{public_file_path}'\n" + str(response.data) + '\n')
+        self.assertEqual(response.status_code, 404,
+                         f"Delete a file outside of workspace: '{public_file_path}'.")
+
+        # Attempt to delete an important system file
+        #
+        # This generates an illegal URL so this doesn't make it to our code.
+        public_file_path = "/etc/passwd"
+        public_file_path = quote(public_file_path, safe='')
+        response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
+                                      headers={'Authorization': token})
+        print(f"Delete system password file Response:'{public_file_path}'\n")
+        self.assertEqual(response.status_code, 404,
+                         f"Delete a system file: '{public_file_path}'..")
+
+        # Try to delete non-existent file
+        public_file_path = "somedirectory/lipics-logo-bw.pdf"
+        public_file_path = quote(public_file_path, safe='')
+        response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
+                                      headers={'Authorization': token})
+        print(f"Delete non-existent file Response:'{public_file_path}'\n" + str(response.data) + '\n')
+        self.assertEqual(response.status_code, 404,
+                         f"Delete non-existent file: '{public_file_path}'.")
+
+        # Try to delete file in subdirectory - valid file deletion
+        public_file_path = "anc/manuscript_Na2.7Ru4O9.tex"
+        public_file_path = quote(public_file_path, safe='')
+        response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
+                                      headers={'Authorization': token})
+        print(f"Delete file in subdirectory anc Response:'{public_file_path}'\n" + str(response.data) + '\n')
+        self.assertEqual(response.status_code, 200,
+                         f"Delete file in subdirectory: '{public_file_path}'.")
+
+        # Try to delete file in subdirectory - valid file deletion
+        public_file_path = "anc/fig8.PNG"
+        public_file_path = quote(public_file_path, safe='')
+        response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
+                                      headers={'Authorization': token})
+        print(f"Delete file in subdirectory anc Response:'{public_file_path}'\n" + str(response.data) + '\n')
+        self.assertEqual(response.status_code, 200,
+                         f"Delete file in subdirectory: '{public_file_path}'.")
+
+        # Try a path that is not hacky but that we know secure_filename() will
+        # filter out characters.
+        #
+        # Reject these filenames for now (because they're a little funny)
+        #
+        # TODO: I suppose we could map ~/ and ./ to root of src directory.
+        #
+        public_file_path = "~/anc/manuscript_Na2.7Ru4O9.tex"
+        public_file_path = quote(public_file_path, safe='')
+        response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
+                                      headers={'Authorization': token})
+        print(f"Delete file in subdirectory anc Response:'{public_file_path}'\n" + str(response.data) + '\n')
+        self.assertEqual(response.status_code, 404,
+                         f"Delete file in subdirectory: '{public_file_path}'.")
+
+        # Technically a legal file path, but where is client coming up with this path? Manually?
+        public_file_path = "./anc/manuscript_Na2.7Ru4O9.tex"
+        public_file_path = quote(public_file_path, safe='')
+        response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}/{public_file_path}",
+                                      headers={'Authorization': token})
+        print(f"Delete file in subdirectory anc Response:'{public_file_path}'\n" + str(response.data) + '\n')
+        self.assertEqual(response.status_code, 404,
+                         f"Delete file in subdirectory: '{public_file_path}'.")
+
+    def test_delete_all_files(self) -> None:
+        """
+        Test delete file operation.
+
+        These tests will focus on triggering delete failures.
+
+        """
+        # Create a token for writing to upload workspace
+        token = generate_token(self.app,
+                               {'scope': ['read:upload', 'write:upload']})
+
+        # Upload a gzipped tar archive package containing files to delete.
+        cwd = os.getcwd()
+        testfiles_dir = os.path.join(cwd, 'tests/test_files_upload')
+        filepath = os.path.join(testfiles_dir, '1801.03879-1.tar.gz')
+
+        # Prepare gzipped tar submission for upload
+        filename = os.path.basename(filepath)
+
+        # Upload files to delete
+        response = self.client.post('/filemanager/api/',
+                                    data={
+                                        # 'file': (io.BytesIO(b"abcdef"), 'test.jpg'),
+                                        #      'file': (open(filepath, 'rb'), 'test.tar.gz'),
+                                        'file': (open(filepath, 'rb'), filename),
+                                    },
+                                    headers={'Authorization': token},
+                                    #        content_type='application/gzip')
+                                    content_type='multipart/form-data')
+
+        self.assertEqual(response.status_code, 201, "Accepted and processed uploaded Submission Contents")
+
+        # This upload should work but we'll check the response anyway
+        with open('schema/resources/uploadResponse.json') as f:
+            schema = json.load(f)
+
+        try:
+            jsonschema.validate(json.loads(response.data), schema)
+        except jsonschema.exceptions.SchemaError as e:
+            self.fail(e)
+
+        upload_data: Dict[str, Any] = json.loads(response.data)
+
+        # Delete all files in my workspace (normal)
+        response = self.client.post(f"/filemanager/api/{upload_data['upload_id']}/delete_all",
+                                    headers={'Authorization': token},
+                                    content_type='multipart/form-data')
+        print("Delete All Files Response:\n" + str(response.data) + '\n')
+        self.assertEqual(response.status_code, 200, "Delete all user-uploaded files.")
+
+    def test_delete_upload_workspace(self) -> None:
+        """
+        Test delete file operation.
+
+        These tests will focus on triggering delete failures.
+
+        """
+
+        # TODO: Need to work on this code after imlementing delete workspace.
+
+        # Create a token for writing to upload workspace
+        token = generate_token(self.app,
+                               {'scope': ['read:upload', 'write:upload']})
+
+        # Delete the workspace
+
+        # Create admin token for deleting upload workspace
+
+        admin_token = generate_token(self.app,
+                                     {'scope': ['read:upload', 'write:upload',
+                                                'admin:upload']})
+        print(f"ADMIN Token (for possible use in manual browser tests): {admin_token}\n")
+
+        response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}",
+                                      headers={'Authorization': admin_token}
+                                      )
+
+        # print("Delete Response:\n" + str(response.data) + '\n')
+
+        # TODO: Delete implementation is coming soon so leave here for now.
+        self.assertEqual(response.status_code, 501, "Accepted request to delete workspace.")
+
+
+
+
+
+
     # Upload a submission package
     def test_upload_files_normal(self) -> None:
         """Test normal well-behaved upload.


### PR DESCRIPTION
This PR implements the delete file (individual file) and delete all files (delete all uploaded files under specified workspace).

There are a significant number of tests for delete file and a smaller number for delete all files.

    nose2 -v tests.test_routes_upload_api.TestUploadAPIRoutes.test_delete_file
    nose2 -v tests.test_routes_upload_api.TestUploadAPIRoutes.test_delete_all_files

The logs contain a significant amount of detail about what is happening. The actual messages will likely improve over time.

source.log: (workspace)

example:
09/Aug/2018:16:09:03 -0400 ********** Delete ALL Files ************

09/Aug/2018:16:09:03 -0400 Delete all files under directory '/tmp/filemanagment/submissions/23/src'
09/Aug/2018:16:09:03 -0400 Delete:'/tmp/filemanagment/submissions/23/src/accessibilityMeta.sty'
09/Aug/2018:16:09:03 -0400 Delete file:'accessibilityMeta.sty'
09/Aug/2018:16:09:03 -0400 Delete:'/tmp/filemanagment/submissions/23/src/anc'
09/Aug/2018:16:09:03 -0400 Delete directory:'anc'
09/Aug/2018:16:09:03 -0400 Delete:'/tmp/filemanagment/submissions/23/src/cc-by.pdf'
09/Aug/2018:16:09:03 -0400 Delete file:'cc-by.pdf'
09/Aug/2018:16:09:03 -0400 Delete:'/tmp/filemanagment/submissions/23/src/defective-fpt.bbl'
09/Aug/2018:16:09:03 -0400 Delete file:'defective-fpt.bbl'
09/Aug/2018:16:09:03 -0400 Delete:'/tmp/filemanagment/submissions/23/src/defective-fpt.tex'
09/Aug/2018:16:09:03 -0400 Delete file:'defective-fpt.tex'
09/Aug/2018:16:09:03 -0400 Delete:'/tmp/filemanagment/submissions/23/src/lipics-logo-bw.pdf'
09/Aug/2018:16:09:03 -0400 Delete file:'lipics-logo-bw.pdf'
09/Aug/2018:16:09:03 -0400 Delete:'/tmp/filemanagment/submissions/23/src/lipics-v2016.cls'
09/Aug/2018:16:09:03 -0400 Delete file:'lipics-v2016.cls'
09/Aug/2018:16:09:03 -0400 ********** Delete File ************

09/Aug/2018:16:09:03 -0400 File to delete not found: 'anc/manuscript_Na2.7Ru4O9.tex' 'anc_manuscript_Na2.7Ru4O9.tex'


upload.log: (service) - (Note: some of these message may not need to be in service log)

09/Aug/2018:16:09:02 -0400 Create new workspace: Upload request: file='UploadWithANCDirectory.tar.gz' archive='None'
09/Aug/2018:16:09:02 -0400 23: Upload files to existing workspace: file='UploadWithANCDirectory.tar.gz'
09/Aug/2018:16:09:02 -0400 23: Processed upload. Saved to DB. Preparing upload summary.
09/Aug/2018:16:09:02 -0400 23: Generating upload summary.
09/Aug/2018:16:09:03 -0400 23: Deleting all uploaded files from this workspace.
09/Aug/2018:16:09:03 -0400 999999: Deleting all uploaded files from this workspace.
09/Aug/2018:16:09:03 -0400 999999: DeleteAllFiles: '404 Not Found: {'upload workspace not found'}'
09/Aug/2018:16:09:03 -0400 23: Delete file 'anc/manuscript_Na2.7Ru4O9.tex'.
09/Aug/2018:16:09:03 -0400 23: DeleteFile: 404 Not Found: {'file not found'}

In the event a suspicious file path is passed to delete file I am logging this in both the source.log and the service level upload.log:

upload.log:

09/Aug/2018:15:50:37 -0400 15: Delete file 'anc/../../etc/passwd'.
09/Aug/2018:15:50:37 -0400 15: SECURITY WARNING: file to delete contains illegal constructs: 'anc/../../etc/passwd'

source.log:
09/Aug/2018:15:50:37 -0400 ********** Delete File ************

09/Aug/2018:15:50:37 -0400 SECURITY WARNING: file to delete contains illegal constructs: 'anc/../../etc/passwd'