### PR TITLE
Arxivng 1075

### DIFF
--- a/filemanager/controllers/upload.py
+++ b/filemanager/controllers/upload.py
@@ -55,6 +55,7 @@ UPLOAD_DELETED_FILE = {'deleted file'}
 UPLOAD_DELETED_WORKSPACE = {'deleted workspace'}
 UPLOAD_FILE_NOT_FOUND = {'file not found'}
 UPLOAD_DELETED_ALL_FILES = {'deleted all files'}
+UPLOAD_WORKSPACE_NOT_FOUND = {'workspcae not found'}
 
 # upload status codes
 INVALID_UPLOAD_ID = {'reason': 'invalid upload identifier'}
@@ -143,6 +144,10 @@ def delete_workspace(upload_id: int) -> Response:
             # Update database (but keep around) for historical reference. Does not
             # consume very much space. What about source log?
             # Create Upload object
+            if upload_obj.state == 'DELETED':
+                logger.info(f"{upload_id}: Workspace has already been deleted:"
+                            f"current state is '{upload_obj.state}'")
+                raise NotFound(UPLOAD_WORKSPACE_NOT_FOUND)
 
             uploadObj = filemanager.process.upload.Upload(upload_id)
 
@@ -162,7 +167,7 @@ def delete_workspace(upload_id: int) -> Response:
         logger.error(f"{upload_obj.upload_id}: Delete workspace request failed ")
         raise InternalServerError(CANT_DELETE_FILE)
     except NotFound as nf:
-        logger.info(f"{upload_id}: DeleteWorkspace: '{nf}'")
+        logger.info(f"{upload_id}: Delete Workspace: '{nf}'")
         raise
     except Exception as ue:
         logger.info("Unknown error in delete workspace. "

--- a/filemanager/process/upload.py
+++ b/filemanager/process/upload.py
@@ -240,9 +240,6 @@ submitter."""
 
         workspace_directory = self.get_upload_directory()
 
-        if not os.path.exists(workspace_directory):
-            raise NotFound(UPLOAD_WORKSPACE_NOT_FOUND)
-
         # Let's stash a copy of the source.log file (if it exists)
         log_path = os.path.join(self.get_upload_directory(), 'source.log')
 
@@ -256,15 +253,19 @@ submitter."""
 
             # Since every source log has the same filename we will prefix
             # upload identifier to log.
-
-            new_filename = str(self.__upload_id) + "_source.log"
+            padded_id = '{0:07d}'.format(self.__upload_id)
+            new_filename = padded_id + "_source.log"
             deleted_log_path = os.path.join(deleted_workspace_logs, new_filename)
             self.log(f"Move '{log_path} to '{deleted_log_path}'.")
+            self.log(f"Delete workspace '{workspace_directory}'.")
             if not shutil.move(log_path, deleted_log_path):
                 self.log('Saving source.log failed.')
                 return False
 
         # Now blow away the workspace
+        if os.path.exists(workspace_directory):
+            shutil.rmtree(workspace_directory)
+
 
         return True
 

--- a/tests/test_routes_upload_api.py
+++ b/tests/test_routes_upload_api.py
@@ -500,7 +500,7 @@ class TestUploadAPIRoutes(TestCase):
         filename = os.path.basename(filepath)
 
         # Upload files to delete
-        response = self.client.post('/filemanager/api/24',
+        response = self.client.post('/filemanager/api/',
                                     data={
                                         'file': (open(filepath, 'rb'), filename),
                                     },
@@ -536,8 +536,33 @@ class TestUploadAPIRoutes(TestCase):
 
         # print("Delete Response:\n" + str(response.data) + '\n')
 
-        # TODO: Delete implementation is coming soon so leave here for now.
-        self.assertEqual(response.status_code, 501, "Accepted request to delete workspace.")
+        self.assertEqual(response.status_code, 200, "Delete workspace.")
+
+        # Let's try to delete the same workspace again
+
+        response = self.client.delete(f"/filemanager/api/{upload_data['upload_id']}",
+                                      headers={'Authorization': admin_token}
+                                      )
+
+        self.assertEqual(response.status_code, 404, "Delete non-existent workspace.")
+
+        # Try and delete a non-sense upload_id
+        response = self.client.delete(f"/filemanager/api/34+14",
+                                      headers={'Authorization': admin_token}
+                                      )
+
+        self.assertEqual(response.status_code, 404, "Delete workspace using bogus upload_id.")
+
+        # Try and delete a non-sense upload_id
+        response = self.client.delete(f"/filemanager/api/../../etc/passwd",
+                                      headers={'Authorization': admin_token}
+                                      )
+
+        self.assertEqual(response.status_code, 404, "Delete workspace using bogus upload_id.")
+
+
+
+        # TODO: Need to add more tests for auth/z for submitter and admin
 
 
 
@@ -656,5 +681,6 @@ class TestUploadAPIRoutes(TestCase):
 
         #print("Delete Response:\n" + str(response.data) + '\n')
 
-        # TODO: Delete implementation is coming soon so leave here for now.
-        self.assertEqual(response.status_code, 501, "Accepted request to delete workspace.")
+        # This cleans out the workspace. Comment out if you want to inspect files
+        # in workspace. Source log is saved to 'deleted_workspace_logs' directory.
+        self.assertEqual(response.status_code, 200, "Accepted request to delete workspace.")


### PR DESCRIPTION
This PR is isolated to Delete Upload Workspace request.

This current implementation stashes a copy of source.log into deleted_workspace_logs. Then is removes the entire upload workspace directory. No backups are made.

DB entry for upload workspace is retained and set to 'DELETED'.

If something else comes to mind I will try to update this description before Monday.