### PR TITLE
Arxivng 1077 1078 1079

### DIFF
--- a/filemanager/routes/upload_api.py
+++ b/filemanager/routes/upload_api.py
@@ -19,6 +19,9 @@ from filemanager.controllers import upload
 
 blueprint = Blueprint('upload_api', __name__, url_prefix='/filemanager/api')
 
+user_id = ''
+scope = ''
+username = ''
 
 def is_owner(session: auth_domain.Session, upload_id: str, **kwargs) -> bool:
     """User must be the upload owner, or an admin."""
@@ -27,8 +30,11 @@ def is_owner(session: auth_domain.Session, upload_id: str, **kwargs) -> bool:
     upload_obj = uploads.retrieve(upload_id)
     if upload_obj is None:
         return True
+    global user_id, username, scope
+    user_id = session.user.user_id
+    username = session.user.username
+    scope = ''.join(session.authorizations.scopes)
     return session.user.user_id == uploads.retrieve(upload_id).owner_user_id
-
 
 @blueprint.route('/status', methods=['GET'])
 def service_status() -> tuple:
@@ -69,7 +75,6 @@ def upload_files(upload_id: int) -> tuple:
     and add to existing upload workspace. Multiple uploads accepted."""
 
     if request.method == 'POST':
-
         archive_arg = request.args.get('archive')
 
         file = request.files.get('file', None)
@@ -80,9 +85,6 @@ def upload_files(upload_id: int) -> tuple:
 
     if request.method == 'GET':
         data, status_code, headers = upload.upload_summary(upload_id)
-
-   # if request.method == 'DELETE':
-    #    data, status_code, headers = upload.delete_workspace(upload_id)
 
     return jsonify(data), status_code, headers
 
@@ -107,7 +109,6 @@ def delete_all_files(upload_id: int) -> tuple:
     return jsonify(data), status_code, headers
 
 
-
 @blueprint.route('<int:upload_id>', methods=['DELETE'])
 @scoped(scopes.ADMIN_UPLOAD)
 def workspace_delete(upload_id: int) -> tuple:
@@ -115,6 +116,48 @@ def workspace_delete(upload_id: int) -> tuple:
 
     data, status_code, headers = upload.delete_workspace(upload_id)
 
+    return jsonify(data), status_code, headers
+
+
+# Lock and unlock upload workspace
+
+@blueprint.route('/<int:upload_id>/lock', methods=['POST'])
+@scoped(scopes.WRITE_UPLOAD, authorizer=is_owner)
+def lock(upload_id: int) -> tuple:
+    """Lock submission (read-only mode) while other services are
+    processing (major state transitions are occurring)."""
+    data, status_code, headers = upload.upload_lock(upload_id)
+    return jsonify(data), status_code, headers
+
+
+# This could be thaw or release instead of unlock
+@blueprint.route('/<int:upload_id>/unlock', methods=['POST'])
+@scoped(scopes.WRITE_UPLOAD, authorizer=is_owner)
+def unlock(upload_id: int) -> tuple:
+    """Unlock submission and enable write mode."""
+    data, status_code, headers = upload.upload_unlock(upload_id)
+    return jsonify(data), status_code, headers
+
+
+# This could be remove or delete instead of release
+@blueprint.route('/<int:upload_id>/release', methods=['POST'])
+@scoped(scopes.WRITE_UPLOAD, authorizer=is_owner)
+def release(upload_id: int) -> tuple:
+    """Client indicates they are finished with submission.
+    File management service is free to remove submissions files,
+    or schedule files for removal at later time."""
+    data, status_code, headers = upload.upload_release(upload_id)
+    return jsonify(data), status_code, headers
+
+
+# This could be remove or delete instead of release
+@blueprint.route('/<int:upload_id>/unrelease', methods=['POST'])
+@scoped(scopes.WRITE_UPLOAD, authorizer=is_owner)
+def unrelease(upload_id: int) -> tuple:
+    """Client indicates they are finished with submission.
+    File management service is free to remove submissions files,
+    or schedule files for removal at later time."""
+    data, status_code, headers = upload.upload_unrelease(upload_id)
     return jsonify(data), status_code, headers
 
 
@@ -135,43 +178,27 @@ def workspace_delete(upload_id: int) -> tuple:
 
 
 # Or would 'download' be a better request? 'disseminate'?
-@blueprint.route('/content/<int:upload_id>', methods=['GET'])
+
+# Get content
+
+@blueprint.route('/<int:upload_id>/content', methods=['GET'])
 @scoped(scopes.READ_UPLOAD)
-def get_files(upload_id: int) -> tuple:
+def get_content(upload_id: int) -> tuple:
     """Return compressed archive containing files."""
     data, status_code, headers = upload.package_content(upload_id)
     return jsonify(data), status_code, headers
 
 
-# This could be freeze instead of lock
-@blueprint.route('/lock/<int:upload_id>', methods=['GET'])
-@scoped(scopes.WRITE_UPLOAD, authorizer=is_owner)
-def lock(upload_id: int) -> tuple:
-    """Lock submission (read-only mode) while other services are
-    processing (major state transitions are occurring)."""
-    data, status_code, headers = upload.upload_lock(upload_id)
+# Or would 'download' be a better request? 'disseminate'?
+@blueprint.route('/<int:upload_id>/<path:public_file_path>/content', methods=['GET'])
+@scoped(scopes.READ_UPLOAD)
+def get_file(upload_id: int) -> tuple:
+    """Return compressed archive containing files."""
+    data, status_code, headers = upload.package_content(upload_id)  # same as content
     return jsonify(data), status_code, headers
 
 
-# This could be thaw or release instead of unlock
-@blueprint.route('/unlock/<int:upload_id>', methods=['GET'])
-@scoped(scopes.WRITE_UPLOAD, authorizer=is_owner)
-def unlock(upload_id: int) -> tuple:
-    """Unlock submission and enable write mode."""
-    data, status_code, headers = upload.upload_unlock(upload_id)
-    return jsonify(data), status_code, headers
-
-
-# This could be remove or delete instead of release
-@blueprint.route('/release/<int:upload_id>', methods=['GET'])
-@scoped(scopes.WRITE_UPLOAD, authorizer=is_owner)
-def release(upload_id: int) -> tuple:
-    """Client indicates they are finished with submission.
-    File management service is free to remove submissions files,
-    or schedule files for removal at later time."""
-    data, status_code, headers = upload.upload_release(upload_id)
-    return jsonify(data), status_code, headers
-
+# Get logs
 
 # This could be get_logs or retrieve_logs instead of logs
 @blueprint.route('/logs/<int:upload_id>', methods=['GET'])

--- a/filemanager/services/uploads/__init__.py
+++ b/filemanager/services/uploads/__init__.py
@@ -4,10 +4,9 @@ from typing import Any, Dict, Optional
 from datetime import datetime
 from werkzeug.local import LocalProxy
 from sqlalchemy.exc import OperationalError
+from arxiv.base.globals import get_application_global
 from filemanager.domain import Upload
 from .models import db, DBUpload
-
-from arxiv.base.globals import get_application_global
 
 
 def init_app(app: Optional[LocalProxy]) -> None:
@@ -59,7 +58,7 @@ def retrieve(upload_id: int, skip_cache: bool = False) -> Optional[Upload]:
             return None
 
         if g:
-            g.uploads[upload_id] = upload_data      # Cache for next time.
+            g.uploads[upload_id] = upload_data  # Cache for next time.
 
     args = {}
     args['upload_id'] = upload_data.upload_id


### PR DESCRIPTION
This PR adds implementations for lock/unlock/release/unrelease requests to file management service.

Tests are also added for all of these requests. I also updated logging requests to use the recommended % with argument form.

I will remove verbose prints of request responses over time. While I'm developing I like to see the responses as I'm tweaking them.

Next PR will focus on content requests unless there are specific requests that other developers need sooner. 

At some point we need to record (log) username of client making requests. I was going to add this (since we now have session info from updated auth) here but arrived at a clean cutoff point and decided to do PR. I'll try to work this into upcoming PRs.

I will update description if I think of anything else. Onward...