### PR TITLE
ARXIVNG-1131 modified time is updated on unpacked files; also fixed mtime localization

### DIFF
--- a/filemanager/process/upload.py
+++ b/filemanager/process/upload.py
@@ -554,7 +554,6 @@ submitter."""
         # convenience.
         def _add_file(fpath: str, warnings: list, errors: list) -> File:
             """Add a file to the :class:`Upload` workspace."""
-
             # Since the filename may have changed, we re-instantiate
             # the File to get the most accurate representation.
             obj = File(fpath, source_directory)
@@ -979,7 +978,6 @@ submitter."""
                 }
                 #if fileObj.removed:
                 #    file_details['removed'] = fileObj.removed
-
                 if not fileObj.removed:
                     file_list.append(file_details)
 

--- a/filemanager/routes/upload_api.py
+++ b/filemanager/routes/upload_api.py
@@ -72,7 +72,6 @@ def upload_files(upload_id: int) -> tuple:
     # Attempt to process upload
     data, status_code, headers = upload.upload(upload_id, file, archive_arg,
                                                request.session.user)
-
     return jsonify(data), status_code, headers
 
 

--- a/filemanager/utilities/unpack.py
+++ b/filemanager/utilities/unpack.py
@@ -116,9 +116,14 @@ def unpack_archive(upload: Upload) -> None:
                             if tarinfo.isreg():
                                 # log this? ("Reg File")
                                 tar.extract(tarinfo, target_directory)
+                                # Update access and modified times to now.
+                                dest = os.path.join(target_directory,
+                                                    tarinfo.name)
+                                os.utime(dest)
                             elif tarinfo.isdir():
                                 # log this? ("Dir")
                                 tar.extract(tarinfo, target_directory)
+                                os.utime(dest)
                             else:
                                 # Warn about entities we don't want to see in
                                 # upload archives


### PR DESCRIPTION
The issue was that unpacked files retain their modified timestamp from when they were originally created. Using ``os.utime`` to update the access/modified timestamps to now. 

Also switched to ``datetime.utcfromtimestamp`` to get the correct UTC datetime from the modified time.