### PR TITLE
ARXIVNG-1072 Implemented HEAD/GET routes for downloading upload as package

### DIFF
--- a/filemanager/controllers/upload.py
+++ b/filemanager/controllers/upload.py
@@ -865,7 +865,7 @@ def upload_unrelease(upload_id: int) -> Response:
     return response_data, status_code, {}
 
 
-def package_content(upload_id: int) -> Response:
+def get_upload_content(upload_id: int) -> Response:
     """Package up files for downloading as a compressed gzipped tar file."""
     upload_db_data: Optional[Upload] = uploads.retrieve(upload_id)
 
@@ -881,7 +881,7 @@ def package_content(upload_id: int) -> Response:
     return filepointer, status.HTTP_200_OK, headers
 
 
-def package_content_status(upload_id: int) -> Response:
+def check_upload_content_exists(upload_id: int) -> Response:
     """Verify that the package content exists/is available."""
     upload_db_data: Optional[Upload] = uploads.retrieve(upload_id)
 

--- a/filemanager/controllers/upload.py
+++ b/filemanager/controllers/upload.py
@@ -893,8 +893,8 @@ def check_upload_content_exists(upload_id: int) -> Response:
     checksum = upload_workspace.content_checksum()
     return {}, status.HTTP_200_OK, {'ETag': checksum}
 
-# TBI
 
+# TBI
 
 def upload_logs(upload_id: int) -> Response:
     """Return logs. Are we talking logs in database or full

--- a/filemanager/process/upload.py
+++ b/filemanager/process/upload.py
@@ -1160,9 +1160,23 @@ submitter."""
             self.pack_content()
         return open(self.get_content_path(), 'rb')
 
+    @property
+    def content_package_exists(self) -> bool:
+        return os.path.exists(self.get_content_path())
+
+    @property
+    def content_package_modified(self) -> datetime:
+        return datetime.utcfromtimestamp(
+            os.path.getmtime(self.get_content_path())
+        )
+
+    @property
+    def content_package_stale(self) -> bool:
+        return self.last_modified > self.content_package_modified
+
     def content_checksum(self) -> str:
         """Return b64-encoded MD5 hash of the packed content tarball."""
-        if not os.path.exists(self.get_content_path()):
+        if not self.content_package_exists or self.content_package_stale:
             self.pack_content()
 
         hash_md5 = md5()

--- a/filemanager/routes/upload_api.py
+++ b/filemanager/routes/upload_api.py
@@ -150,6 +150,34 @@ def unrelease(upload_id: int) -> tuple:
     return jsonify(data), status_code, headers
 
 
+# Get content
+
+@blueprint.route('/<int:upload_id>/content', methods=['HEAD'])
+@scoped(scopes.READ_UPLOAD)
+def check_upload_content_exists(upload_id: int) -> tuple:
+    """
+    Verify that upload content exists.
+
+    Returns an ``ETag`` header with the current source package checksum.
+    """
+    data, status_code, headers = upload.check_upload_content_exists(upload_id)
+    return jsonify(data), status_code, headers
+
+
+@blueprint.route('/<int:upload_id>/content', methods=['GET'])
+@scoped(scopes.READ_UPLOAD)
+def get_upload_content(upload_id: int) -> tuple:
+    """
+    Get the upload content as a compressed tarball.
+
+    Returns a stream with mimetype ``application/tar+gzip``, and an ``ETag``
+    header with the current source package checksum.
+    """
+    data, status_code, headers = upload.get_upload_content(upload_id)
+    response = send_file(data, mimetype="application/tar+gzip")
+    response.set_etag(headers.get('ETag'))
+    return response
+
 # TODO: The requests below need to be evaluated and/or implemented
 
 # Was debating about 'manifest' request but upload GET request
@@ -167,25 +195,6 @@ def unrelease(upload_id: int) -> tuple:
 
 
 # Or would 'download' be a better request? 'disseminate'?
-
-# Get content
-
-@blueprint.route('/<int:upload_id>/content', methods=['HEAD'])
-@scoped(scopes.READ_UPLOAD)
-def get_content_status(upload_id: int) -> tuple:
-    """Return compressed archive containing files."""
-    data, status_code, headers = upload.package_content_status(upload_id)
-    return jsonify(data), status_code, headers
-
-
-@blueprint.route('/<int:upload_id>/content', methods=['GET'])
-@scoped(scopes.READ_UPLOAD)
-def get_content(upload_id: int) -> tuple:
-    """Return compressed archive containing files."""
-    data, status_code, headers = upload.package_content(upload_id)
-    response = send_file(data, mimetype="application/tar+gzip")
-    response.set_etag(headers.get('ETag'))
-    return response
 
 
 # Or would 'download' be a better request? 'disseminate'?

--- a/filemanager/utilities/unpack.py
+++ b/filemanager/utilities/unpack.py
@@ -16,7 +16,6 @@ import zipfile
 
 from filemanager.arxiv.file import File
 
-from filemanager.process.upload import Upload
 
 ERROR_MSG_PRE = 'There were problems unpacking "'
 ERROR_MSG_SUF = '" -- continuing. Please try again and confirm your files.'
@@ -26,7 +25,7 @@ ERROR_MSG_SUF = '" -- continuing. Please try again and confirm your files.'
 DEBUG = 0
 
 
-def unpack_archive(upload: Upload) -> None:
+def unpack_archive(upload: 'Upload') -> None:
     """
     Uppack specified archive and recursively traverse the source directory
     and unpack any additional gzipped/tar archives contained within original

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -240,8 +240,6 @@ paths:
                 type: string
                 format: binary
 
-  # These are a bit different from what is currently implemented in
-  # routes/ui.py. Maybe this provides a bit more RESTful semantics?
   /{upload_id}/content:
     parameters:
       -in: path

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -250,16 +250,24 @@ paths:
        required: true
        schema:
          type: string
+
+    head:
+      operationId: checkUploadContentExists
+      summary: Verify that upload content exists.
+      responses:
+        '200':
+          description: Content exists for this upload package.
+          headers:
+            ETag:
+              description: |
+                Base64-encoded MD5 checksum of the upload package (as a
+                tarball).
+              schema:
+                type: str
+
     get:
       operationId: getUploadContent
       summary: Retrieve the sanitized/processed upload package.
-      parameters:
-        -in: path
-         name: upload_id
-         description: Unique long-lived identifier for the upload.
-         required: true
-         schema:
-           type: string
       responses:
         '200':
           description: Returns the sanitized/processed upload package.
@@ -268,6 +276,13 @@ paths:
               schema:
                 type: string
                 format: binary
+          headers:
+            ETag:
+              description: |
+                Base64-encoded MD5 checksum of the upload package (as a
+                tarball).
+              schema:
+                type: str
         '401':
           description: Unauthorized. Missing valid authentication information.
         '403':

--- a/tests/test_pack_content.py
+++ b/tests/test_pack_content.py
@@ -62,11 +62,9 @@ class TestPackContent(TestCase):
         mock_get_base_dir.return_value = self.base_directory
         self.upload.pack_content()
         checksum = self.upload.content_checksum()
-        for i in range(50):
-            self.upload.pack_content()
-            self.assertEqual(checksum, self.upload.content_checksum(),
-                             'The checksum should remain the same across '
-                             'rebuilds of the same content.')
+        self.assertEqual(checksum, self.upload.content_checksum(),
+                         'The checksum should remain the same.')
+
 
     @mock.patch(f'{upload.__name__}._get_base_directory')
     def test_get_content(self, mock_get_base_dir):

--- a/tests/test_pack_content.py
+++ b/tests/test_pack_content.py
@@ -1,0 +1,76 @@
+"""Tests related to packing source content for download."""
+
+import os
+from unittest import TestCase, mock
+from datetime import datetime
+import tempfile
+import tarfile
+from werkzeug.datastructures import FileStorage
+from werkzeug.utils import secure_filename
+
+import shutil
+
+from filemanager.process import upload
+
+TEST_FILES_DIRECTORY = os.path.join(os.getcwd(), 'tests/test_files_upload')
+
+
+class TestPackContent(TestCase):
+    @mock.patch(f'{upload.__name__}._get_base_directory')
+    def setUp(self, mock_get_base_dir):
+        """Create a new upload workspace."""
+        self.base_directory = tempfile.mkdtemp()
+        mock_get_base_dir.return_value = self.base_directory
+        file_path = os.path.join(TEST_FILES_DIRECTORY, 'upload5.tar.gz')
+        self.upload_id = 12345
+        with open(file_path, 'rb') as fp:
+            # Now create upload instance
+            self.upload = upload.Upload(self.upload_id)
+            # Process upload
+            self.upload.process_upload(FileStorage(fp))
+
+    @mock.patch(f'{upload.__name__}._get_base_directory')
+    def test_get_content_path(self, mock_get_base_dir):
+        """Generate the intended path for the content tarball."""
+        mock_get_base_dir.return_value = self.base_directory
+        expected = os.path.join(self.base_directory, str(self.upload_id),
+                                f'{self.upload_id}.tar.gz')
+        self.assertEqual(self.upload.get_content_path(), expected)
+
+    @mock.patch(f'{upload.__name__}._get_base_directory')
+    def test_pack_content(self, mock_get_base_dir):
+        """Generate a tarball from the upload content."""
+        mock_get_base_dir.return_value = self.base_directory
+        expected = os.path.join(self.base_directory, str(self.upload_id),
+                                f'{self.upload_id}.tar.gz')
+
+        content_path = self.upload.pack_content()
+
+        self.assertEqual(content_path, expected,
+                         "Returns path to content file")
+        self.assertTrue(os.path.exists(content_path), "Content file exists")
+        self.assertTrue(tarfile.is_tarfile(content_path),
+                        "Created file is a tarball")
+
+        tar = tarfile.open(content_path)
+        self.assertIn('upload5.pdf', [ti.name for ti in tar],
+                      "Includes content from original file")
+
+    @mock.patch(f'{upload.__name__}._get_base_directory')
+    def test_content_checksum(self, mock_get_base_dir):
+        """Generate a checksum based on the tarball content."""
+        mock_get_base_dir.return_value = self.base_directory
+        self.upload.pack_content()
+        checksum = self.upload.content_checksum()
+        for i in range(50):
+            self.upload.pack_content()
+            self.assertEqual(checksum, self.upload.content_checksum(),
+                             'The checksum should remain the same across '
+                             'rebuilds of the same content.')
+
+    @mock.patch(f'{upload.__name__}._get_base_directory')
+    def test_get_content(self, mock_get_base_dir):
+        """Generate a pointer to the content tarball."""
+        mock_get_base_dir.return_value = self.base_directory
+        pointer = self.upload.get_content()
+        self.assertTrue(hasattr(pointer, 'read'), "Returns an IO")


### PR DESCRIPTION
Implements these operations:

```yaml
/{upload_id}/content:
    parameters:
      -in: path
       name: upload_id
       description: Unique long-lived identifier for the upload.
       required: true
       schema:
         type: string

    head:
      operationId: checkUploadContentExists
      summary: Verify that upload content exists.
      responses:
        '200':
          description: Content exists for this upload package.
          headers:
            ETag:
              description: |
                Base64-encoded MD5 checksum of the upload package (as a
                tarball).
              schema:
                type: str

    get:
      operationId: getUploadContent
      summary: Retrieve the sanitized/processed upload package.
      responses:
        '200':
          description: Returns the sanitized/processed upload package.
          content:
            application/octet-stream:
              schema:
                type: string
                format: binary
          headers:
            ETag:
              description: |
                Base64-encoded MD5 checksum of the upload package (as a
                tarball).
              schema:
                type: str
        '401':
          description: Unauthorized. Missing valid authentication information.
        '403':
          description: |
            Forbidden. Client or user is not authorized to download this
            package.
```