### PR TITLE
ARXIVNG-1175 Support for ancillary files

### DIFF
--- a/filemanager/arxiv/file.py
+++ b/filemanager/arxiv/file.py
@@ -5,10 +5,13 @@
 import os.path
 import re
 from datetime import datetime
+from pytz import timezone
 
 from arxiv.base import logging
 
 from filemanager.arxiv.file_type import guess, _is_tex_type, name
+
+EST = timezone('US/Eastern')
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +33,8 @@ class File:
         self.__type = self.initialize_type()
         self.__size = os.path.getsize(self.filepath)
         mtime = os.path.getmtime(filepath)
-        self.__modified_datetime = datetime.utcfromtimestamp(mtime)
+        mtime_est = datetime.utcfromtimestamp(mtime).astimezone(EST)
+        self.__modified_datetime = mtime_est
 
     @property
     def name(self) -> str:
@@ -168,7 +172,8 @@ class File:
         logger.debug('Get modified_datetime')
         if os.path.exists(self.filepath):
             mt = os.path.getmtime(self.filepath)
-            self.__modified_datetime = datetime.utcfromtimestamp(mt)
+            mt_et = datetime.utcfromtimestamp(mt).astimezone(EST)
+            self.__modified_datetime = mt_et
         return self.__modified_datetime.isoformat()
 
     @property

--- a/filemanager/arxiv/file.py
+++ b/filemanager/arxiv/file.py
@@ -5,13 +5,11 @@
 import os.path
 import re
 from datetime import datetime
-from pytz import timezone
+from pytz import UTC
 
 from arxiv.base import logging
 
 from filemanager.arxiv.file_type import guess, _is_tex_type, name
-
-EST = timezone('US/Eastern')
 
 logger = logging.getLogger(__name__)
 
@@ -33,8 +31,7 @@ class File:
         self.__type = self.initialize_type()
         self.__size = os.path.getsize(self.filepath)
         mtime = os.path.getmtime(filepath)
-        mtime_est = datetime.utcfromtimestamp(mtime).astimezone(EST)
-        self.__modified_datetime = mtime_est
+        self.__modified_datetime = datetime.fromtimestamp(mtime, tz=UTC)
 
     @property
     def name(self) -> str:
@@ -172,8 +169,7 @@ class File:
         logger.debug('Get modified_datetime')
         if os.path.exists(self.filepath):
             mt = os.path.getmtime(self.filepath)
-            mt_et = datetime.utcfromtimestamp(mt).astimezone(EST)
-            self.__modified_datetime = mt_et
+            self.__modified_datetime = datetime.fromtimestamp(mt, tz=UTC)
         return self.__modified_datetime.isoformat()
 
     @property

--- a/filemanager/controllers/upload.py
+++ b/filemanager/controllers/upload.py
@@ -321,7 +321,7 @@ def client_delete_all_files(upload_id: str) -> Response:
 
 
 def upload(upload_id: int, file: FileStorage, archive: str,
-           user: auth_domain.User) -> Response:
+           user: auth_domain.User, ancillary: bool = False) -> Response:
     """Upload individual files or compressed archive. Unpack and add
     files to upload_db_data workspace.
 
@@ -329,11 +329,15 @@ def upload(upload_id: int, file: FileStorage, archive: str,
     ----------
     upload_id : int
         The unique identifier for the upload_db_data in question.
-    file : FileStorage
+    file : :class:`FileStorage`
         File archive to be processed.
-    archive: str
+    archive : str
         Archive submission is targeting. Oversize thresholds are curently
         specified at the archive level.
+    ancillary : bool
+        If ``True``, the file is to be treated as an ancillary file. This means
+        (presently) that the file is stored in a special subdirectory within
+        the source package.
 
     Returns
     -------
@@ -446,7 +450,7 @@ def upload(upload_id: int, file: FileStorage, archive: str,
             upload_workspace = filemanager.process.upload.Upload(upload_id)
 
             # Process upload_db_data
-            upload_workspace.process_upload(file)
+            upload_workspace.process_upload(file, ancillary=ancillary)
 
             completion_datetime = datetime.utcnow().astimezone(EST)
 

--- a/filemanager/controllers/upload.py
+++ b/filemanager/controllers/upload.py
@@ -2,6 +2,7 @@
 
 from typing import Tuple, Optional
 from datetime import datetime
+from pytz import timezone
 import json
 import logging
 
@@ -91,6 +92,8 @@ ACCEPTED = {'reason': 'upload in progress'}
 MISSING_NAME = {'an upload needs a name'}
 
 SOME_ERROR = {'Need to define and assign better error'}
+
+EST = timezone('US/Eastern')
 
 Response = Tuple[Optional[dict], int, dict]
 
@@ -391,9 +394,10 @@ def upload(upload_id: int, file: FileStorage, archive: str,
             else:
                 arch = archive
 
+            current_time = datetime.utcnow().astimezone(EST)
             new_upload = Upload(owner_user_id=user_id, archive=arch,
-                                created_datetime=datetime.now(),
-                                modified_datetime=datetime.now(),
+                                created_datetime=current_time,
+                                modified_datetime=current_time,
                                 state=Upload.ACTIVE)
             # Store in DB
             uploads.store(new_upload)
@@ -436,7 +440,7 @@ def upload(upload_id: int, file: FileStorage, archive: str,
                         "workspace: file='%s'", upload_db_data.upload_id, file.filename)
 
             # Keep track of how long processing upload_db_data takes
-            start_datetime = datetime.now()
+            start_datetime = datetime.utcnow().astimezone(EST)
 
             # Create Upload object
             upload_workspace = filemanager.process.upload.Upload(upload_id)
@@ -444,7 +448,7 @@ def upload(upload_id: int, file: FileStorage, archive: str,
             # Process upload_db_data
             upload_workspace.process_upload(file)
 
-            completion_datetime = datetime.now()
+            completion_datetime = datetime.utcnow().astimezone(EST)
 
             # Keep track of files processed (this included deleted files)
             file_list = upload_workspace.create_file_upload_summary()

--- a/filemanager/controllers/upload.py
+++ b/filemanager/controllers/upload.py
@@ -2,7 +2,7 @@
 
 from typing import Tuple, Optional
 from datetime import datetime
-from pytz import timezone
+from pytz import UTC
 import json
 import logging
 
@@ -72,7 +72,7 @@ UPLOAD_WORKSPACE_ALREADY_DELETED = 'Request failed. Workspace has been deleted.'
 # MISSING_UPLOAD_ID = {'reason': 'missing upload id'}
 
 # Indicate requests that have not been implemented yet.
-REQUEST_NOT_IMPLEMENTED = {'request not implemented'}
+REQUUTC_NOT_IMPLEMENTED = {'request not implemented'}
 
 # upload status
 NO_SUCH_THING = {'reason': 'there is no upload'}
@@ -92,8 +92,6 @@ ACCEPTED = {'reason': 'upload in progress'}
 MISSING_NAME = {'an upload needs a name'}
 
 SOME_ERROR = {'Need to define and assign better error'}
-
-EST = timezone('US/Eastern')
 
 Response = Tuple[Optional[dict], int, dict]
 
@@ -398,7 +396,7 @@ def upload(upload_id: int, file: FileStorage, archive: str,
             else:
                 arch = archive
 
-            current_time = datetime.utcnow().astimezone(EST)
+            current_time = datetime.now(UTC)
             new_upload = Upload(owner_user_id=user_id, archive=arch,
                                 created_datetime=current_time,
                                 modified_datetime=current_time,
@@ -444,7 +442,7 @@ def upload(upload_id: int, file: FileStorage, archive: str,
                         "workspace: file='%s'", upload_db_data.upload_id, file.filename)
 
             # Keep track of how long processing upload_db_data takes
-            start_datetime = datetime.utcnow().astimezone(EST)
+            start_datetime = datetime.now(UTC)
 
             # Create Upload object
             upload_workspace = filemanager.process.upload.Upload(upload_id)
@@ -452,7 +450,7 @@ def upload(upload_id: int, file: FileStorage, archive: str,
             # Process upload_db_data
             upload_workspace.process_upload(file, ancillary=ancillary)
 
-            completion_datetime = datetime.utcnow().astimezone(EST)
+            completion_datetime = datetime.now(UTC)
 
             # Keep track of files processed (this included deleted files)
             file_list = upload_workspace.create_file_upload_summary()
@@ -680,7 +678,7 @@ def upload_lock(upload_id: int) -> Response:
 
 def upload_unlock(upload_id: int) -> Response:
     """Unlock upload workspace."""
-    # response_data = ERROR_REQUEST_NOT_IMPLEMENTED
+    # response_data = ERROR_REQUUTC_NOT_IMPLEMENTED
     # status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
     logger.info("%s: Unlock upload workspace.", upload_id)
 
@@ -907,11 +905,11 @@ def check_upload_content_exists(upload_id: int) -> Response:
 def upload_logs(upload_id: int) -> Response:
     """Return logs. Are we talking logs in database or full
     source logs. Need to implement logs first!!! """
-    # response_data = ERROR_REQUEST_NOT_IMPLEMENTED
+    # response_data = ERROR_REQUUTC_NOT_IMPLEMENTED
     # status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
     if 1 + upload_id:
         print(upload_id)  # make pylint happy - increase my score!
-        raise NotImplementedError(REQUEST_NOT_IMPLEMENTED)
+        raise NotImplementedError(REQUUTC_NOT_IMPLEMENTED)
     response_data = ACCEPTED
     status_code = status.HTTP_202_ACCEPTED
     return response_data, status_code, {}

--- a/filemanager/controllers/upload.py
+++ b/filemanager/controllers/upload.py
@@ -72,7 +72,7 @@ UPLOAD_WORKSPACE_ALREADY_DELETED = 'Request failed. Workspace has been deleted.'
 # MISSING_UPLOAD_ID = {'reason': 'missing upload id'}
 
 # Indicate requests that have not been implemented yet.
-REQUUTC_NOT_IMPLEMENTED = {'request not implemented'}
+REQUEST_NOT_IMPLEMENTED = {'request not implemented'}
 
 # upload status
 NO_SUCH_THING = {'reason': 'there is no upload'}
@@ -678,7 +678,7 @@ def upload_lock(upload_id: int) -> Response:
 
 def upload_unlock(upload_id: int) -> Response:
     """Unlock upload workspace."""
-    # response_data = ERROR_REQUUTC_NOT_IMPLEMENTED
+    # response_data = ERROR_REQUEST_NOT_IMPLEMENTED
     # status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
     logger.info("%s: Unlock upload workspace.", upload_id)
 
@@ -905,11 +905,11 @@ def check_upload_content_exists(upload_id: int) -> Response:
 def upload_logs(upload_id: int) -> Response:
     """Return logs. Are we talking logs in database or full
     source logs. Need to implement logs first!!! """
-    # response_data = ERROR_REQUUTC_NOT_IMPLEMENTED
+    # response_data = ERROR_REQUEST_NOT_IMPLEMENTED
     # status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
     if 1 + upload_id:
         print(upload_id)  # make pylint happy - increase my score!
-        raise NotImplementedError(REQUUTC_NOT_IMPLEMENTED)
+        raise NotImplementedError(REQUEST_NOT_IMPLEMENTED)
     response_data = ACCEPTED
     status_code = status.HTTP_202_ACCEPTED
     return response_data, status_code, {}

--- a/filemanager/process/upload.py
+++ b/filemanager/process/upload.py
@@ -3,7 +3,7 @@
 import os
 import re
 from datetime import datetime
-from pytz import timezone
+from pytz import UTC
 import shutil
 import tarfile
 import logging
@@ -25,8 +25,6 @@ UPLOAD_DELETE_FILE_FAILED = 'unable to delete file'
 UPLOAD_DELETE_ALL_FILE_FAILED = 'unable to delete all file'
 UPLOAD_FILE_NOT_FOUND = 'file not found'
 UPLOAD_WORKSPACE_NOT_FOUND = 'workspcae not found'
-
-EST = timezone('US/Eastern')
 
 
 def _get_base_directory() -> str:
@@ -1175,7 +1173,7 @@ submitter."""
         most_recent = max(os.path.getmtime(root)
                           for root, _, _
                           in os.walk(self.get_source_directory()))
-        return datetime.utcfromtimestamp(most_recent).astimezone(EST)
+        return datetime.fromtimestamp(most_recent, tz=UTC)
 
     def get_content(self) -> io.BytesIO:
         """Get a file-pointer for the packed content tarball."""
@@ -1189,9 +1187,10 @@ submitter."""
 
     @property
     def content_package_modified(self) -> datetime:
-        return datetime.utcfromtimestamp(
-            os.path.getmtime(self.get_content_path())
-        ).astimezone(EST)
+        return datetime.fromtimestamp(
+            os.path.getmtime(self.get_content_path()),
+            tz=UTC
+        )
 
     @property
     def content_package_stale(self) -> bool:

--- a/filemanager/process/upload.py
+++ b/filemanager/process/upload.py
@@ -3,6 +3,7 @@
 import os
 import re
 from datetime import datetime
+from pytz import timezone
 import shutil
 import tarfile
 import logging
@@ -24,6 +25,8 @@ UPLOAD_DELETE_FILE_FAILED = 'unable to delete file'
 UPLOAD_DELETE_ALL_FILE_FAILED = 'unable to delete all file'
 UPLOAD_FILE_NOT_FOUND = 'file not found'
 UPLOAD_WORKSPACE_NOT_FOUND = 'workspcae not found'
+
+EST = timezone('US/Eastern')
 
 
 def _get_base_directory() -> str:
@@ -1152,7 +1155,7 @@ submitter."""
         most_recent = max(os.path.getmtime(root)
                           for root, _, _
                           in os.walk(self.get_source_directory()))
-        return datetime.utcfromtimestamp(most_recent)
+        return datetime.utcfromtimestamp(most_recent).astimezone(EST)
 
     def get_content(self) -> io.BytesIO:
         """Get a file-pointer for the packed content tarball."""
@@ -1168,7 +1171,7 @@ submitter."""
     def content_package_modified(self) -> datetime:
         return datetime.utcfromtimestamp(
             os.path.getmtime(self.get_content_path())
-        )
+        ).astimezone(EST)
 
     @property
     def content_package_stale(self) -> bool:

--- a/filemanager/routes/upload_api.py
+++ b/filemanager/routes/upload_api.py
@@ -66,12 +66,13 @@ def new_upload() -> tuple:
 def upload_files(upload_id: int) -> tuple:
     """Upload individual files or compressed archive
     and add to existing upload workspace. Multiple uploads accepted."""
-
-    archive_arg = request.args.get('archive')
+    archive_arg = request.form.get('archive')
+    ancillary = request.form.get('ancillary', None) is not None
     file = request.files.get('file', None)
     # Attempt to process upload
     data, status_code, headers = upload.upload(upload_id, file, archive_arg,
-                                               request.session.user)
+                                               request.session.user,
+                                               ancillary=ancillary)
     return jsonify(data), status_code, headers
 
 

--- a/filemanager/services/uploads/__init__.py
+++ b/filemanager/services/uploads/__init__.py
@@ -2,14 +2,12 @@
 
 from typing import Any, Dict, Optional
 from datetime import datetime
-from pytz import timezone
+from pytz import UTC
 from werkzeug.local import LocalProxy
 from sqlalchemy.exc import OperationalError
 from arxiv.base.globals import get_application_global
 from filemanager.domain import Upload
 from .models import db, DBUpload
-
-EST = timezone('US/Eastern')
 
 
 def init_app(app: Optional[LocalProxy]) -> None:
@@ -68,16 +66,16 @@ def retrieve(upload_id: int, skip_cache: bool = False) -> Optional[Upload]:
     args['owner_user_id'] = upload_data.owner_user_id
     args['archive'] = upload_data.archive
 
-    args['created_datetime'] = upload_data.created_datetime.astimezone(EST)
-    args['modified_datetime'] = upload_data.modified_datetime.astimezone(EST)
+    args['created_datetime'] = upload_data.created_datetime.replace(tzinfo=UTC)
+    args['modified_datetime'] = upload_data.modified_datetime.replace(tzinfo=UTC)
     args['state'] = upload_data.state
     args['lock'] = upload_data.lock
 
     if upload_data.lastupload_start_datetime is not None:
-        args['lastupload_start_datetime'] = upload_data.lastupload_start_datetime.astimezone(EST)
+        args['lastupload_start_datetime'] = upload_data.lastupload_start_datetime.astimezone(UTC)
 
     if upload_data.lastupload_completion_datetime is not None:
-        args['lastupload_completion_datetime'] = upload_data.lastupload_completion_datetime.astimezone(EST)
+        args['lastupload_completion_datetime'] = upload_data.lastupload_completion_datetime.astimezone(UTC)
 
     if upload_data.lastupload_logs is not None:
         args['lastupload_logs'] = upload_data.lastupload_logs
@@ -161,7 +159,7 @@ def update(upload_update_data: Upload) -> None:
     upload_data.lock = upload_update_data.lock
 
     # Always set this when workspace DB entry is updated
-    upload_data.modified_datetime = datetime.utcnow().astimezone(EST)
+    upload_data.modified_datetime = datetime.now(UTC)
 
     # TODO: Would user ever need to set the modification time manually?
     # upload_data.modified_datetime = upload_update_data.modified_datetime

--- a/filemanager/services/uploads/__init__.py
+++ b/filemanager/services/uploads/__init__.py
@@ -65,18 +65,16 @@ def retrieve(upload_id: int, skip_cache: bool = False) -> Optional[Upload]:
     args['upload_id'] = upload_data.upload_id
     args['owner_user_id'] = upload_data.owner_user_id
     args['archive'] = upload_data.archive
-
     args['created_datetime'] = upload_data.created_datetime.replace(tzinfo=UTC)
     args['modified_datetime'] = upload_data.modified_datetime.replace(tzinfo=UTC)
     args['state'] = upload_data.state
     args['lock'] = upload_data.lock
 
     if upload_data.lastupload_start_datetime is not None:
-        args['lastupload_start_datetime'] = upload_data.lastupload_start_datetime.astimezone(UTC)
+        args['lastupload_start_datetime'] = upload_data.lastupload_start_datetime.replace(tzinfo=UTC)
 
     if upload_data.lastupload_completion_datetime is not None:
-        args['lastupload_completion_datetime'] = upload_data.lastupload_completion_datetime.astimezone(UTC)
-
+        args['lastupload_completion_datetime'] = upload_data.lastupload_completion_datetime.replace(tzinfo=UTC)
     if upload_data.lastupload_logs is not None:
         args['lastupload_logs'] = upload_data.lastupload_logs
 
@@ -104,7 +102,6 @@ def store(new_upload_data: Upload) -> Upload:
     RuntimeError
         When there is some other problem.
     """
-    print(new_upload_data.created_datetime)
     upload_data = DBUpload(owner_user_id=new_upload_data.owner_user_id,
                            archive=new_upload_data.archive,
                            created_datetime=new_upload_data.created_datetime,

--- a/filemanager/tasks.py
+++ b/filemanager/tasks.py
@@ -42,7 +42,7 @@ def sanitize_upload(upload_id: int, file: FileStorage, with_sleep: int = 15) -> 
         # Revisit how to handle error
         raise RuntimeError('No such thing! %s' % upload_id)
 
-    start_datetime = datetime.now()
+    start_datetime = datetime.now(UTC)
     #uploadObj = filemanager.process.Upload.process_upload(upload)
     uploadObj = filemanager.process.upload.Upload(upload_id)
 
@@ -52,7 +52,7 @@ def sanitize_upload(upload_id: int, file: FileStorage, with_sleep: int = 15) -> 
     # Process upload
     uploadObj.process_upload(file)
 
-    completion_datetime = datetime.now()
+    completion_datetime = datetime.now(UTC)
 
     # Colect information we want to retain
     upload.lastupload_logs = str(uploadObj.get_warnings())

--- a/generate_token.py
+++ b/generate_token.py
@@ -1,6 +1,6 @@
 import click
 
-from pytz import timezone
+from pytz import UTC
 import uuid
 from datetime import timedelta, datetime
 from arxiv.users import auth, domain
@@ -41,7 +41,7 @@ def generate_token(user_id: str, email: str, username: str,
                    scope: str = 'upload:read,upload:write,upload:admin') \
         -> None:
     # Specify the validity period for the session.
-    start = datetime.now(tz=timezone('US/Eastern'))
+    start = datetime.now(tz=UTC)
     end = start + timedelta(seconds=36000)   # Make this as long as you want.
 
     # Create a user with endorsements in astro-ph.CO and .GA.

--- a/populate_test_database.py
+++ b/populate_test_database.py
@@ -13,9 +13,9 @@ app.app_context().push()
 def populate_database():
     """Initialize the search index."""
     uploads.db.create_all()
-    uploads.db.session.add(uploads.DBUpload(name='The first upload', created_datetime=datetime.now(),submission_id='1234567'))
-    uploads.db.session.add(uploads.DBUpload(name='The second upload', created_datetime=datetime.now(),submission_id='1234568'))
-    uploads.db.session.add(uploads.DBUpload(name='The third upload', created_datetime=datetime.now(),submission_id='1234569'))
+    uploads.db.session.add(uploads.DBUpload(name='The first upload', created_datetime=datetime.now(UTC),submission_id='1234567'))
+    uploads.db.session.add(uploads.DBUpload(name='The second upload', created_datetime=datetime.now(UTC),submission_id='1234568'))
+    uploads.db.session.add(uploads.DBUpload(name='The third upload', created_datetime=datetime.now(UTC),submission_id='1234569'))
     uploads.db.session.commit()
 
 

--- a/schema/openapi.yaml
+++ b/schema/openapi.yaml
@@ -102,6 +102,7 @@ paths:
         '403':
           description: |
             Forbidden. Client is not authorized to access this upload.
+
     post:
       operationId: addFilesToPackage
       summary: |

--- a/tests/test_ancillary_upload.py
+++ b/tests/test_ancillary_upload.py
@@ -1,0 +1,37 @@
+"""Tests ancillary file handling."""
+
+import os
+from unittest import TestCase, mock
+from datetime import datetime
+import tempfile
+from werkzeug.datastructures import FileStorage
+from werkzeug.utils import secure_filename
+
+import shutil
+
+from filemanager.process import upload
+
+
+class TestUploadAncillaryFile(TestCase):
+    """Test uploading an ancillary file."""
+
+    @mock.patch(f'{upload.__name__}._get_base_directory')
+    def test_upload_ancillary(self, mock_get_base_dir):
+        """Uploaded file is marked as ancillary."""
+        UPLOAD_BASE_DIRECTORY = tempfile.mkdtemp()
+        mock_get_base_dir.return_value = UPLOAD_BASE_DIRECTORY
+        _, fpath = tempfile.mkstemp(suffix='.md')
+        with open(fpath, 'w') as f:
+            f.write('Some content')
+
+        with open(fpath, 'rb') as fp:
+            file = FileStorage(fp)
+            # Now create upload instance
+            u = upload.Upload(12345)
+            # Process upload
+            u.process_upload(file, ancillary=True)
+
+        ancillary_path = u.get_ancillary_directory()
+        _, fname = os.path.split(fpath)
+        self.assertIn(fname, os.listdir(ancillary_path),
+                      'File should be stored in the ancillary directory')

--- a/tests/test_routes_upload_api.py
+++ b/tests/test_routes_upload_api.py
@@ -2,7 +2,7 @@
 
 from unittest import TestCase, mock
 from datetime import datetime, timedelta
-from pytz import timezone
+from pytz import UTC
 import json
 import tempfile
 from io import BytesIO
@@ -27,7 +27,7 @@ from arxiv import status
 def generate_token(app: Flask, scope: List[str]) -> str:
     """Helper function for generating a JWT."""
     secret = app.config.get('JWT_SECRET')
-    start = datetime.now(tz=timezone('US/Eastern'))
+    start = datetime.now(tz=UTC)
     end = start + timedelta(seconds=36000)  # Make this as long as you want.
     user_id = '1'
     email = 'foo@bar.com'
@@ -237,8 +237,8 @@ class TestUploadAPIRoutes(TestCase):
         token = generate_token(self.app, [auth.scopes.READ_UPLOAD,
                                           auth.scopes.WRITE_UPLOAD])
 
-        created = datetime.now()
-        modified = datetime.now()
+        created = datetime.now(UTC)
+        modified = datetime.now(UTC)
         expected_data = {'upload_id': 5,
                          'status': "SUCCEEDED",
                          'create_datetime': created.isoformat(),
@@ -861,8 +861,8 @@ class TestUploadAPIRoutes(TestCase):
                                           auth.scopes.WRITE_UPLOAD,
                                           auth.scopes.DELETE_UPLOAD_FILE])
 
-        created = datetime.now()
-        modified = datetime.now()
+        created = datetime.now(UTC)
+        modified = datetime.now(UTC)
         expected_data = {'upload_id': 5,
                          'status': "SUCCEEDED",
                          'create_datetime': created.isoformat(),

--- a/tests/test_service_upload.py
+++ b/tests/test_service_upload.py
@@ -2,13 +2,11 @@
 
 from unittest import TestCase, mock
 from datetime import datetime
-from pytz import timezone
+from pytz import UTC
 from typing import Any
 import sqlalchemy
 from filemanager.services import uploads
 from filemanager.domain import Upload
-
-EST = timezone('US/Eastern')
 
 
 class TestUploadGetter(TestCase):
@@ -30,8 +28,8 @@ class TestUploadGetter(TestCase):
         uploads.db.create_all()
 
         self.data = dict(owner_user_id='dlf2', archive='physics',
-                         created_datetime=datetime.utcnow().astimezone(EST),
-                         modified_datetime=datetime.utcnow().astimezone(EST),
+                         created_datetime=datetime.now(UTC),
+                         modified_datetime=datetime.now(UTC),
                          state="ACTIVE")
         self.dbupload = self.uploads.DBUpload(**self.data)  # type: ignore
         self.uploads.db.session.add(self.dbupload)  # type: ignore
@@ -85,8 +83,8 @@ class TestUploadCreator(TestCase):
         self.uploads.db.app = app  # type: ignore
         self.uploads.db.create_all()  # type: ignore
 
-        self.data = {'owner_user_id': 'dlf2', 'archive': 'physics', 'created_datetime': datetime.now(),
-                     'modified_datetime': datetime.now(), 'state': "ACTIVE"}
+        self.data = {'owner_user_id': 'dlf2', 'archive': 'physics', 'created_datetime': datetime.now(UTC),
+                     'modified_datetime': datetime.now(UTC), 'state': "ACTIVE"}
         self.dbupload = self.uploads.DBUpload(**self.data)  # type: ignore
         self.uploads.db.session.add(self.dbupload)  # type: ignore
         self.uploads.db.session.commit()  # type: ignore
@@ -100,8 +98,8 @@ class TestUploadCreator(TestCase):
 
     def test_store_an_upload(self) -> None:
         """A new row is added for the upload."""
-        existing_upload = Upload(owner_user_id='dlf2', archive='physics', created_datetime=datetime.now(),
-                                 modified_datetime=datetime.now(), state="ACTIVE")
+        existing_upload = Upload(owner_user_id='dlf2', archive='physics', created_datetime=datetime.now(UTC),
+                                 modified_datetime=datetime.now(UTC), state="ACTIVE")
 
         self.uploads.store(existing_upload)  # type: ignore
         self.assertGreater(existing_upload.upload_id, 0, "Upload.id is updated with pk id")
@@ -129,7 +127,7 @@ class TestUploadUpdater(TestCase):
         self.uploads.db.app = app  # type: ignore
         self.uploads.db.create_all()  # type: ignore
 
-        self.data = dict(owner_user_id='dlf2', archive='physics', created_datetime=datetime.now())
+        self.data = dict(owner_user_id='dlf2', archive='physics', created_datetime=datetime.now(UTC))
         self.dbupload = self.uploads.DBUpload(**self.data)  # type: ignore
         self.uploads.db.session.add(self.dbupload)  # type: ignore
         self.uploads.db.session.commit()  # type: ignore

--- a/tests/test_service_upload.py
+++ b/tests/test_service_upload.py
@@ -2,11 +2,13 @@
 
 from unittest import TestCase, mock
 from datetime import datetime
-
+from pytz import timezone
 from typing import Any
 import sqlalchemy
 from filemanager.services import uploads
 from filemanager.domain import Upload
+
+EST = timezone('US/Eastern')
 
 
 class TestUploadGetter(TestCase):
@@ -28,8 +30,8 @@ class TestUploadGetter(TestCase):
         uploads.db.create_all()
 
         self.data = dict(owner_user_id='dlf2', archive='physics',
-                         created_datetime=datetime.now(),
-                         modified_datetime=datetime.now(),
+                         created_datetime=datetime.utcnow().astimezone(EST),
+                         modified_datetime=datetime.utcnow().astimezone(EST),
                          state="ACTIVE")
         self.dbupload = self.uploads.DBUpload(**self.data)  # type: ignore
         self.uploads.db.session.add(self.dbupload)  # type: ignore

--- a/tests/test_unit_file.py
+++ b/tests/test_unit_file.py
@@ -3,6 +3,9 @@ from filemanager.arxiv.file import File
 
 import os.path
 import datetime
+from pytz import timezone
+
+EST = timezone('US/Eastern')
 
 
 class TestFileClass(TestCase):
@@ -38,7 +41,7 @@ class TestFileClass(TestCase):
         self.assertEquals(file.ext, '.gif', "Check ext() method is '.gif'")
         self.assertEquals(file.size, 495, "Check size of '.gif' is 495")
         mtime = os.path.getmtime(file.filepath)
-        modified_datetime = datetime.datetime.utcfromtimestamp(mtime).isoformat()
+        modified_datetime = datetime.datetime.utcfromtimestamp(mtime).astimezone(EST).isoformat()
         self.assertEquals(file.modified_datetime, modified_datetime, "Check modification time of file.")
 
     def test_file_subdirectory(self):

--- a/tests/test_unit_file.py
+++ b/tests/test_unit_file.py
@@ -3,9 +3,7 @@ from filemanager.arxiv.file import File
 
 import os.path
 import datetime
-from pytz import timezone
-
-EST = timezone('US/Eastern')
+from pytz import UTC
 
 
 class TestFileClass(TestCase):
@@ -41,7 +39,7 @@ class TestFileClass(TestCase):
         self.assertEquals(file.ext, '.gif', "Check ext() method is '.gif'")
         self.assertEquals(file.size, 495, "Check size of '.gif' is 495")
         mtime = os.path.getmtime(file.filepath)
-        modified_datetime = datetime.datetime.utcfromtimestamp(mtime).astimezone(EST).isoformat()
+        modified_datetime = datetime.datetime.fromtimestamp(mtime, tz=UTC).isoformat()
         self.assertEquals(file.modified_datetime, modified_datetime, "Check modification time of file.")
 
     def test_file_subdirectory(self):


### PR DESCRIPTION
This implements a feature that allows the client to explicitly mark an uploaded file as ancillary. In that case, the file is added to the ancillary directory.

This PR also includes localization of datetimes across the service, to support https://github.com/cul-it/arxiv-submission-ui/pull/31