### PR TITLE
ARXIVNG 1195

### DIFF
--- a/filemanager/arxiv/file.py
+++ b/filemanager/arxiv/file.py
@@ -6,7 +6,8 @@ import os.path
 import re
 from datetime import datetime
 from pytz import UTC
-
+from hashlib import md5
+from base64 import b64encode
 from arxiv.base import logging
 
 from filemanager.arxiv.file_type import guess, _is_tex_type, name
@@ -139,6 +140,28 @@ class File:
     def sha256sum(self) -> str:
         """Calculate sha256 Checksum."""
         return 'NOT IMPLEMENTED YET'
+
+    @property
+    def checksum(self) -> str:
+        """
+        Calculate MD5 checksum for file.
+
+        Returns
+        -------
+        Returns Null string if file does not exist otherwise
+        return b64-encoded MD5 hash of the specified file.
+
+        """
+
+        if os.path.exists(self.filepath):
+            hash_md5 = md5()
+            with open(self.filepath, "rb") as f:
+                for chunk in iter(lambda: f.read(4096), b""):
+                    hash_md5.update(chunk)
+            return b64encode(hash_md5.digest()).decode('utf-8')
+        else:
+            return ""
+
 
     @property
     def description(self) -> str:

--- a/filemanager/routes/upload_api.py
+++ b/filemanager/routes/upload_api.py
@@ -180,7 +180,33 @@ def get_upload_content(upload_id: int) -> tuple:
     response.set_etag(headers.get('ETag'))
     return response
 
-# TODO Need to implement single file download.
+@blueprint.route('/<int:upload_id>/<path:public_file_path>/content', methods=['HEAD'])
+@scoped(scopes.READ_UPLOAD)
+def check_file_exists(upload_id: int, public_file_path: str) -> tuple:
+    """
+    Verify specified file exists.
+
+    Returns an ``ETag`` header with the current source file checksum.
+    """
+    data, status_code, headers = upload.check_upload_file_content_exists(upload_id, public_file_path)
+
+    return jsonify(data), status_code, headers
+
+
+@blueprint.route('/<int:upload_id>/<path:public_file_path>/content', methods=['GET'])
+@scoped(scopes.READ_UPLOAD)
+def get_file_content(upload_id: int, public_file_path: str) -> tuple:
+    """
+    Return content of specified file.
+
+    """
+
+    data, status_code, headers = upload.get_upload_file_content(upload_id, public_file_path)
+
+    response = send_file(data, mimetype="application/*")
+    response.set_etag(headers.get('ETag'))
+    return response
+
 
 # Get logs
 
@@ -252,34 +278,6 @@ def get_upload_service_log() -> tuple:
     response = send_file(data, mimetype="application/tar+gzip")
     response.set_etag(headers.get('ETag'))
     return response
-
-
-
-# TODO: The requests below need to be evaluated and/or implemented
-
-# Was debating about 'manifest' request but upload GET request
-# seems to do same thing (though that one returns file information
-# generated during file processing.
-#
-# Will upload GET always return list of files?
-#
-# @blueprint.route('/manifest/<int:upload_id>', methods=['GET'])
-# @scoped('read:upload')
-# def manifest(upload_id: int) -> tuple:
-#    """Manifest of files contained in upload package."""
-#    #data, status_code, headers = upload.generate_manifest(upload_id)
-#    return jsonify(data), status_code, headers
-
-
-# Or would 'download' be a better request? 'disseminate'?
-
-
-# Or would 'download' be a better request? 'disseminate'?
-@blueprint.route('/<int:upload_id>/<path:public_file_path>/content', methods=['GET'])
-@scoped(scopes.READ_UPLOAD)
-def get_file(upload_id: int) -> tuple:
-    """Return compressed archive containing files."""
-    pass
 
 # Exception handling
 

--- a/tests/test_unit_file.py
+++ b/tests/test_unit_file.py
@@ -33,6 +33,7 @@ class TestFileClass(TestCase):
 
         # TODO implement sha256sum function
         self.assertEquals(file.sha256sum, "NOT IMPLEMENTED YET", "Check sha256sum method()")
+        self.assertEquals(file.checksum, "8KwlZuQvByH23+4HIcANGQ==", "Generate checksum (MD5)")
         file.description = 'This is my favorite photo.'
         self.assertEquals(file.description, 'This is my favorite photo.', "Check description() method")
         self.assertEquals(file.is_tex_type, False, "Check is_tex_type() method")


### PR DESCRIPTION
This PR covers ARXIVNG-1195 and implements individual file 'exists' and 'download' requests. This is basically HEAD/GET <file> content with a relative file argument. This is one of the last critical requests needed for a fully functional submission UI interface.

I have also added the size and modify date time to all HEAD 'exists' requests for content/individual files/logs. This uncovered a bug in content head routine.

If the content download package does not already exist the checksum is always null.  If content package doesn't exists the HEAD request never builds the package. This means if you followed protocol and do a head request first you will NEVER get the OK (checksum) to download the content package.

I added a call in content existence check routine to build content package when the content package file does not exist.

I still need to implement content replace request for admins.

Nice to end the week by wrapping up open task with tests, bug fixes,  and a PR.