### PR TITLE
ARXIVNG-1235

### DIFF
--- a/filemanager/process/upload.py
+++ b/filemanager/process/upload.py
@@ -240,7 +240,10 @@ submitter."""
 
         if shutil.move(filepath, removed_path):
             # lmsg = "*** File " + file.name + f" has been removed. Reason: {msg} ***"
-            lmsg = f"Removed hidden file {file.name}."
+            if msg:
+                lmsg = msg
+            else:
+                lmsg = f"Removed file {file.name}."
             self.add_warning(file.public_filepath, lmsg)
         else:
             self.add_warning("*** FAILED to remove file " + filepath + " ***")
@@ -636,6 +639,9 @@ submitter."""
         upload_path = os.path.join(src_directory, filename)
         file.save(upload_path)
         if os.stat(upload_path).st_size == 0:
+            # Might be a good to delete zero length file we just deposited
+            # in upload workspace.
+            os.remove(upload_path)
             raise BadRequest(UPLOAD_FILE_EMPTY)
         return upload_path
 
@@ -709,7 +715,7 @@ submitter."""
                     # self.add_warning(obj.public_filepath, msg)
                     _warnings.append(msg)
                     obj = _add_file(file_path, _warnings, _errors)
-                    self.remove_file(obj, f"Removed: {msg}")
+                    self.remove_file(obj, f"Removed {obj.name} [file is empty]")
                     continue
 
                 # Remove 10240 byte all-null files (bad user tar attempts?)

--- a/filemanager/utilities/unpack.py
+++ b/filemanager/utilities/unpack.py
@@ -211,12 +211,13 @@ def unpack_archive(upload: 'Upload') -> None:
 
                 # Hanlde .zip files
                 elif obj.type == 'zip' and zipfile.is_zipfile(path):
+                    target_directory = os.path.join(source_directory, root_directory)
                     print("*******Process zip archive: " + path)
-                    msg = f"***** unpack {obj.type} {file} to dir: {source_directory}"
+                    msg = f"***** unpack {obj.type} {file} to dir: {target_directory}"
                     upload.log(msg)
                     try:
                         with zipfile.ZipFile(path, "r") as zip_ref:
-                            zip_ref.extractall(source_directory)
+                            zip_ref.extractall(target_directory)
                             # Now move zip file out of way to removed directory
                             rem_path = os.path.join(removed_directory, os.path.basename(path))
                             msg = f"Removed packed file {file}"

--- a/tests/test_process_upload.py
+++ b/tests/test_process_upload.py
@@ -206,11 +206,11 @@ class TestUpload(TestCase):
     # TODO: Keep these old tests around for when I need specialized tests
     def XXtest_process_compressed_upload(self) -> None:
 
-        """Try to process compressed archive upload"""
+        """Test that we are generating warnings when zero length files are uploaded."""
         upload_id = 20180229
         upload = Upload(upload_id)
 
-        filename = os.path.join(TEST_FILES_DIRECTORY, 'BorelPaper.tex.Z')
+        filename = os.path.join(TEST_FILES_DIRECTORY, 'upload1.tar.gz')
 
         # For testing purposes, clean out existing workspace directory
         workspace_dir = upload.create_upload_workspace()
@@ -226,7 +226,10 @@ class TestUpload(TestCase):
             upload = Upload(upload_id)
             ret = upload.process_upload(file)
 
-        print("Process tgz upload: " + ret)
+        if upload.has_warnings():
+            print("Upload has warnings")
+            for warn in upload.get_warnings():
+                print(f"Warning: {warn}")
 
     def test_process_unpack(self) -> None:
         """


### PR DESCRIPTION
This is a relatively small PR that was originally intended to fix the incorrect unpacking on zip archives into the top level directory when 'Ancillary' box is checked.

The code to handle zip files was not modified after the option to unpack into 'ancillary' directory. Set target destination correctly and appears to work.

Also fixed issue where zero size files remain in file list. This file is now removed so that the file summary does not pick it up.

Minor change to remove file routine to use provided warning message.
